### PR TITLE
Assorted fixes

### DIFF
--- a/examples/openmm/autodoxysummary.rst
+++ b/examples/openmm/autodoxysummary.rst
@@ -28,6 +28,7 @@ Output
 .. autodoxysummary::
    :toctree: generated/
 
-   OpenMM::NonbondedForce
-   OpenMM::VerletIntegrator
-   OpenMM::CustomIntegrator
+   ~OpenMM::NonbondedForce
+   ~OpenMM::VerletIntegrator
+   ~OpenMM::CustomIntegrator
+   ~OpenMM::System

--- a/examples/openmm/index.rst
+++ b/examples/openmm/index.rst
@@ -11,4 +11,3 @@ This page show some examples using Doxygen XML from OpenMM.
    autodoxyclass
    autodoxymethod
    extra_test_pages
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Sphinx==1.3.1
 docutils>=0.11
 Jinja2>=2.3
 lxml
-mock ; python_version < '3.3'
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-sphinx==1.3.1
+Sphinx==1.3.1
 docutils>=0.11
-jinja2>=2.3
+Jinja2>=2.3
 lxml
+mock ; python_version < '3.3'

--- a/sphinxcontrib/autodoc_doxygen/autodoc.py
+++ b/sphinxcontrib/autodoc_doxygen/autodoc.py
@@ -221,11 +221,20 @@ class DoxygenMethodDocumenter(DoxygenDocumenter):
         return doc
 
     def format_name(self):
-        # return self.object.find('definition').text
+        def text(el):
+            if el.text is not None:
+                return el.text
+            return ''
+
+        def tail(el):
+            if el.tail is not None:
+                return el.tail
+            return ''
+
         rtype_el = self.object.find('type')
         rtype_el_ref = rtype_el.find('ref')
         if rtype_el_ref is not None:
-            rtype = rtype_el_ref.text
+            rtype = text(rtype_el) + text(rtype_el_ref) + tail(rtype_el_ref)
         else:
             rtype = rtype_el.text
 

--- a/sphinxcontrib/autodoc_doxygen/xmlutils.py
+++ b/sphinxcontrib/autodoc_doxygen/xmlutils.py
@@ -76,8 +76,18 @@ class _DoxygenXmlParagraphFormatter(object):
         self.continue_line = False
 
     def visit_parametername(self, node):
-        self.lines.append(':param %s: ' % node.text)
+        if 'direction' in node.attrib:
+            direction = '[%s] ' % node.get('direction')
+        else:
+            direction = ''
+
+        self.lines.append('**%s** -- %s' % (
+            node.text, direction))
         self.continue_line = True
+
+    def visit_parameterlist(self, node):
+        lines = [l for l in type(self)().generic_visit(node).lines if l is not '']
+        self.lines.extend([':parameters:', ''] + ['* %s' % l for l in lines] + [''])
 
     def visit_simplesect(self, node):
         if node.get('kind') == 'return':
@@ -114,3 +124,5 @@ class _DoxygenXmlParagraphFormatter(object):
         else:
             raise ValueError(node)
 
+    def visit_subscript(self, node):
+        self.lines[-1] += '\ :sub:`%s` %s' % (node.text, node.tail)

--- a/tests/test_format_xml_paragraph.py
+++ b/tests/test_format_xml_paragraph.py
@@ -20,7 +20,9 @@ def test_1():
     expected = """
 Get a reference to a tabulated function that may appear in the energy expression.
 
-:param index: the index of the function to get
+:parameters:
+
+* **index** -- the index of the function to get
 
 :returns: the :cpp:any:`TabulatedFunction` object defining the function
 
@@ -114,4 +116,133 @@ Add a tabulated function that may appear in the energy expression.
    This method exists only for backward compatibility. Use :cpp:any:`addTabulatedFunction()` instead.
 
 """
+    assert '\n'.join(format_xml_paragraph(node)) == expected
+
+
+def test_6():
+    node = ET.fromstring('''<detaileddescription>
+<para>Set the force group this <ref refid="classOpenMM_1_1Force" kindref="compound">Force</ref> belongs to.</para><para><parameterlist kind="param"><parameteritem>
+<parameternamelist>
+<parametername>group</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the group index. Legal values are between 0 and 31 (inclusive). </para></parameterdescription>
+</parameteritem>
+</parameterlist>
+</para>        </detaileddescription>''')
+
+    expected = """
+Set the force group this :cpp:any:`Force` belongs to.
+
+:parameters:
+
+* **group** -- the group index. Legal values are between 0 and 31 (inclusive).
+
+"""
+    assert '\n'.join(format_xml_paragraph(node)) == expected
+
+
+def test_7():
+    node = ET.fromstring('''<detaileddescription>
+<para>Add an angle term to the force field.</para><para><parameterlist kind="param"><parameteritem>
+<parameternamelist>
+<parametername>particle1</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the index of the first particle connected by the angle </para></parameterdescription>
+</parameteritem>
+<parameteritem>
+<parameternamelist>
+<parametername>particle2</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the index of the second particle connected by the angle </para></parameterdescription>
+</parameteritem>
+<parameteritem>
+<parameternamelist>
+<parametername>particle3</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the index of the third particle connected by the angle </para></parameterdescription>
+</parameteritem>
+<parameteritem>
+<parameternamelist>
+<parametername>length</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the equilibrium angle, measured in degrees </para></parameterdescription>
+</parameteritem>
+<parameteritem>
+<parameternamelist>
+<parametername>quadraticK</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the quadratic force constant for the angle, measured in kJ/mol/radian^2 </para></parameterdescription>
+</parameteritem>
+</parameterlist>
+<simplesect kind="return"><para>the index of the angle that was added </para></simplesect>
+</para>        </detaileddescription>''')
+
+    expected = """
+Add an angle term to the force field.
+
+:parameters:
+
+* **particle1** -- the index of the first particle connected by the angle
+* **particle2** -- the index of the second particle connected by the angle
+* **particle3** -- the index of the third particle connected by the angle
+* **length** -- the equilibrium angle, measured in degrees
+* **quadraticK** -- the quadratic force constant for the angle, measured in kJ/mol/radian^2
+
+:returns: the index of the angle that was added
+
+"""
+    assert '\n'.join(format_xml_paragraph(node)) == expected
+
+
+def test_8():
+    node = ET.fromstring('''<detaileddescription>
+<para>This is a <ref refid="classOpenMM_1_1VirtualSite" kindref="compound">VirtualSite</ref> that computes the particle location based on three other particles&apos; locations. If r<subscript>1</subscript> is the location of particle 1, r<subscript>12</subscript> is the vector from particle 1 to particle 2, and r<subscript>13</subscript> is the vector from particle 1 to particle 3, then the virtual site location is given by</para><para>r<subscript>1</subscript> + w<subscript>12</subscript>r<subscript>12</subscript> + w<subscript>13</subscript>r<subscript>13</subscript> + w<subscript>cross</subscript>(r<subscript>12</subscript> x r<subscript>13</subscript>)</para><para>The three weight factors are user-specified. This allows the virtual site location to be out of the plane of the three particles. </para>    </detaileddescription>''')
+
+    expected = '''
+This is a :cpp:any:`VirtualSite` that computes the particle location based on three other particles' locations. If r\ :sub:`1`  is the location of particle 1, r\ :sub:`12`  is the vector from particle 1 to particle 2, and r\ :sub:`13`  is the vector from particle 1 to particle 3, then the virtual site location is given by
+
+r\ :sub:`1`  + w\ :sub:`12` r\ :sub:`12`  + w\ :sub:`13` r\ :sub:`13`  + w\ :sub:`cross` (r\ :sub:`12`  x r\ :sub:`13` )
+
+The three weight factors are user-specified. This allows the virtual site location to be out of the plane of the three particles.
+'''
+
+    assert '\n'.join(format_xml_paragraph(node)) == expected
+
+
+def test_9():
+    node = ET.fromstring('''
+<detaileddescription>
+<para>Get the force field parameters for an angle term.</para><para><parameterlist kind="param"><parameteritem>
+<parameternamelist>
+<parametername>index</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the index of the angle for which to get parameters </para></parameterdescription>
+</parameteritem>
+<parameteritem>
+<parameternamelist>
+<parametername direction="out">particle1</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the index of the first particle forming the angle </para></parameterdescription>
+</parameteritem>
+</parameterlist>
+</para>
+</detaileddescription>''')
+
+    expected = '''
+Get the force field parameters for an angle term.
+
+:parameters:
+
+* **index** -- the index of the angle for which to get parameters
+* **particle1** -- [out] the index of the first particle forming the angle
+
+'''
     assert '\n'.join(format_xml_paragraph(node)) == expected

--- a/tests/test_method_formatter.py
+++ b/tests/test_method_formatter.py
@@ -1,0 +1,66 @@
+from mock import Mock
+from contextlib import contextmanager
+
+import lxml.etree as ET
+from sphinxcontrib.autodoc_doxygen.autodoc import (DoxygenMethodDocumenter,
+                                                   AutoDirective)
+import sphinxcontrib.autodoc_doxygen
+
+
+@contextmanager
+def set_doxygen_root(node):
+    have_old_root = False
+    if hasattr(sphinxcontrib.autodoc_doxygen.setup, 'DOXYGEN_ROOT'):
+        old_root = sphinxcontrib.autodoc_doxygen.setup.DOXYGEN_ROOT
+        have_old_root = True
+         
+    sphinxcontrib.autodoc_doxygen.setup.DOXYGEN_ROOT = node
+    yield
+
+    if have_old_root:
+        sphinxcontrib.autodoc_doxygen.setup.DOXYGEN_ROOT = old_root
+    else:
+        delattr(sphinxcontrib.autodoc_doxygen.setup, 'DOXYGEN_ROOT')
+         
+
+def test_1():
+    node = ET.fromstring('''
+  <compounddef id="classOpenMM_1_1System" kind="class" language="C++" prot="public">
+    <compoundname>OpenMM::System</compoundname>
+      <sectiondef kind="public-func">
+      <memberdef kind="function" id="classOpenMM_1_1System_1ade51122d3a2ff91c394af280a3d3a375" prot="public" static="no" const="yes" explicit="no" inline="no" virt="non-virtual">
+        <type>const <ref refid="classOpenMM_1_1Force" kindref="compound">Force</ref> &amp;</type>
+        <definition>const Force&amp; OpenMM::System::getForce</definition>
+        <argsstring>(int index) const </argsstring>
+        <name>getForce</name>
+        <param>
+          <type>int</type>
+          <declname>index</declname>
+        </param>
+        <briefdescription>
+        </briefdescription>
+        <detaileddescription>
+<para>Get a const reference to one of the Forces in this <ref refid="classOpenMM_1_1System" kindref="compound">System</ref>.</para><para><parameterlist kind="param"><parameteritem>
+<parameternamelist>
+<parametername>index</parametername>
+</parameternamelist>
+<parameterdescription>
+<para>the index of the <ref refid="classOpenMM_1_1Force" kindref="compound">Force</ref> to get </para></parameterdescription>
+</parameteritem>
+</parameterlist>
+</para>        </detaileddescription>
+        <inbodydescription>
+        </inbodydescription>
+        <location file="/Users/rmcgibbo/projects/openmm/openmmapi/include/openmm/System.h" line="200" column="1"/>
+      </memberdef>
+    </sectiondef>
+  </compounddef>''')
+
+    with set_doxygen_root(node):
+        directive = Mock()
+        documenter = DoxygenMethodDocumenter(directive, "OpenMM::System::getForce", id="classOpenMM_1_1System_1ade51122d3a2ff91c394af280a3d3a375")
+
+        documenter.parse_name()
+        documenter.import_object()
+        assert documenter.format_name() == 'const Force & getForce'
+        assert documenter.format_signature() == '(int index) const '


### PR DESCRIPTION
Fixes for the following issues from https://github.com/pandegroup/openmm/pull/1238#issuecomment-164607334 and https://github.com/pandegroup/openmm/pull/1238#issuecomment-164608109:
- "when a method takes a single argument, there's no bullet mark in front of it. For example, if the argument is called "index", it just says, "Parameters index". That looks kind of strange. Also, the first parameter is always listed on the same line as the word "Parameters"."
- "When a return value is a reference, the & is missing."
- `<sub>` tags don't render properly in a method description.
- Pass-by-reference method parameters that are used for output (`@param[out]` vs `@param` in doxygen comments) aren't demarcated separately.
