### PR TITLE
[WIP] Changes to work with Sphinx 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ env:
 sudo: false
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
+  - "3.6"
+  - "3.8"
 
 notifications:
   email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==1.5
+Sphinx>=2.0
 docutils>=0.11
 Jinja2>=2.3
 lxml

--- a/sphinxcontrib/autodoc_doxygen/autodoc.py
+++ b/sphinxcontrib/autodoc_doxygen/autodoc.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division
 
 from six import itervalues
 from lxml import etree as ET
-from sphinx.ext.autodoc import Documenter, AutoDirective, members_option, ALL
+from sphinx.ext.autodoc import Documenter, members_option, ALL
 from sphinx.errors import ExtensionError
 
 from . import get_doxygen_root
@@ -83,7 +83,7 @@ class DoxygenDocumenter(Documenter):
         # document non-skipped members
         memberdocumenters = []
         for (mname, member, isattr) in self.filter_members(members, want_all):
-            classes = [cls for cls in itervalues(AutoDirective._registry)
+            classes = [cls for cls in itervalues(self.env.app.registry.documenters)
                        if cls.can_document_member(member, mname, isattr, self)]
             if not classes:
                 # don't know how to document this member
@@ -146,7 +146,7 @@ class DoxygenClassDocumenter(DoxygenDocumenter):
     def format_name(self):
         return self.fullname
 
-    def get_doc(self, encoding):
+    def get_doc(self):
         detaileddescription = self.object.find('detaileddescription')
         doc = [format_xml_paragraph(detaileddescription)]
         return doc
@@ -215,7 +215,7 @@ class DoxygenMethodDocumenter(DoxygenDocumenter):
         self.object = match[0]
         return True
 
-    def get_doc(self, encoding):
+    def get_doc(self):
         detaileddescription = self.object.find('detaileddescription')
         doc = [format_xml_paragraph(detaileddescription)]
         return doc

--- a/sphinxcontrib/autodoc_doxygen/autosummary/__init__.py
+++ b/sphinxcontrib/autodoc_doxygen/autosummary/__init__.py
@@ -24,14 +24,13 @@ def import_by_name(name, env=None, prefixes=None, i=0):
         prefixes = [None]
 
     if env is not None:
-        parent = env.ref_context.get('cpp:parent_symbol')
-        parent_symbols = []
-        while parent is not None and parent.identifier is not None:
-            parent_symbols.insert(0, str(parent.identifier))
-            parent = parent.parent
-        prefixes.append('::'.join(parent_symbols))
+        parents = env.ref_context.get('cpp:parent_key')
+        if parents is not None:
+            parent_symbols = [p[0].get_display_string() for p in parents]
+            prefixes.append('::'.join(parent_symbols))
 
     tried = []
+
     for prefix in prefixes:
         try:
             if prefix:
@@ -208,12 +207,9 @@ class DoxygenAutoEnum(DoxygenAutosummary):
         env = self.state.document.settings.env
         self.name = names[0]
 
-        try:
-            real_name, obj, parent, modname = import_by_name(self.name, env=env)
-            names = [n.text for n in obj.findall('./enumvalue/name')]
-            descriptions = [format_xml_paragraph(d) for d in obj.findall('./enumvalue/detaileddescription')]
-        except:
-            return zip(names, ['' for n in names])
+        real_name, obj, parent, modname = import_by_name(self.name, env=env)
+        names = [n.text for n in obj.findall('./enumvalue/name')]
+        descriptions = [format_xml_paragraph(d) for d in obj.findall('./enumvalue/detaileddescription')]
         return zip(names, descriptions)
 
     def get_table(self, items):

--- a/sphinxcontrib/autodoc_doxygen/autosummary/generate.py
+++ b/sphinxcontrib/autodoc_doxygen/autosummary/generate.py
@@ -196,7 +196,7 @@ def process_generate_options(app):
     if not genfiles:
         return
 
-    ext = app.config.source_suffix[0]
+    ext = list(app.config.source_suffix)[0]
     genfiles = [genfile + (not genfile.endswith(ext) and ext or '')
                 for genfile in genfiles]
 

--- a/tests/test_method_formatter.py
+++ b/tests/test_method_formatter.py
@@ -2,8 +2,7 @@ from mock import Mock
 from contextlib import contextmanager
 
 import lxml.etree as ET
-from sphinxcontrib.autodoc_doxygen.autodoc import (DoxygenMethodDocumenter,
-                                                   AutoDirective)
+from sphinxcontrib.autodoc_doxygen.autodoc import DoxygenMethodDocumenter
 import sphinxcontrib.autodoc_doxygen
 
 


### PR DESCRIPTION
I tested with Sphinx 2.0.0 and 2.3.1 (the latest release) and it works on both of them.  It does not work with 1.x versions.

There's one part to this that is not correct, but I'm stuck trying to figure out how to do it correctly.  Perhaps you'll have some insight.  Enums aren't getting documented correctly.  For example, `OpenMM::NonbondedForce::NonbondedMethod`.  `import_by_name()` gets called with just the name `NonbondedMethod`.  It passes that to `_import_by_name()`, which apparently expects to be given the name of a top level class and therefore throws an exception.  As a workaround I added the try/except block in `get_items()`, which at least lets it run, but that produces empty tables for the enumerated values.