### PR TITLE
Use briefdescription in autosummary table if it is available

### DIFF
--- a/sphinxcontrib/autodoc_doxygen/autodoc.py
+++ b/sphinxcontrib/autodoc_doxygen/autodoc.py
@@ -151,6 +151,14 @@ class DoxygenClassDocumenter(DoxygenDocumenter):
         doc = [format_xml_paragraph(detaileddescription)]
         return doc
 
+    def get_brief(self):
+        briefdescription = self.object.find('briefdescription')
+        if briefdescription is None:
+            return None
+
+        brief = [format_xml_paragraph(briefdescription)]
+        return brief
+
     def get_object_members(self, want_all):
         all_members = self.object.xpath('.//sectiondef[@kind="public-func" '
             'or @kind="public-static-func"]/memberdef[@kind="function"]')
@@ -219,6 +227,14 @@ class DoxygenMethodDocumenter(DoxygenDocumenter):
         detaileddescription = self.object.find('detaileddescription')
         doc = [format_xml_paragraph(detaileddescription)]
         return doc
+
+    def get_brief(self):
+        briefdescription = self.object.find('briefdescription')
+        if briefdescription is None:
+            return None
+
+        brief = [format_xml_paragraph(briefdescription)]
+        return brief
 
     def format_name(self):
         def text(el):

--- a/sphinxcontrib/autodoc_doxygen/autodoc.py
+++ b/sphinxcontrib/autodoc_doxygen/autodoc.py
@@ -104,6 +104,20 @@ class DoxygenDocumenter(Documenter):
         self.env.temp_data['autodoc:module'] = None
         self.env.temp_data['autodoc:class'] = None
 
+    def get_doc(self):
+        detaileddescription = self.object.find('detaileddescription')
+        doc = [format_xml_paragraph(detaileddescription)]
+        return doc
+
+    def get_brief(self):
+        briefdescription = self.object.find('briefdescription')
+        if briefdescription is None:
+            return None
+
+        brief = [format_xml_paragraph(briefdescription)]
+        return brief
+
+
 
 class DoxygenClassDocumenter(DoxygenDocumenter):
     objtype = 'doxyclass'
@@ -145,19 +159,6 @@ class DoxygenClassDocumenter(DoxygenDocumenter):
 
     def format_name(self):
         return self.fullname
-
-    def get_doc(self):
-        detaileddescription = self.object.find('detaileddescription')
-        doc = [format_xml_paragraph(detaileddescription)]
-        return doc
-
-    def get_brief(self):
-        briefdescription = self.object.find('briefdescription')
-        if briefdescription is None:
-            return None
-
-        brief = [format_xml_paragraph(briefdescription)]
-        return brief
 
     def get_object_members(self, want_all):
         all_members = self.object.xpath('.//sectiondef[@kind="public-func" '
@@ -222,19 +223,6 @@ class DoxygenMethodDocumenter(DoxygenDocumenter):
                                  'the following xpath: "%s"' % (tuple(self.fullname.rsplit('::', 1)) + (xpath_query,)))
         self.object = match[0]
         return True
-
-    def get_doc(self):
-        detaileddescription = self.object.find('detaileddescription')
-        doc = [format_xml_paragraph(detaileddescription)]
-        return doc
-
-    def get_brief(self):
-        briefdescription = self.object.find('briefdescription')
-        if briefdescription is None:
-            return None
-
-        brief = [format_xml_paragraph(briefdescription)]
-        return brief
 
     def format_name(self):
         def text(el):

--- a/sphinxcontrib/autodoc_doxygen/autosummary/__init__.py
+++ b/sphinxcontrib/autodoc_doxygen/autosummary/__init__.py
@@ -127,8 +127,17 @@ class DoxygenAutosummary(Autosummary):
 
             # -- Grab the summary
             documenter.add_content(None)
-            doc = list(documenter.process_doc([self.bridge.result.data]))
+            brief = documenter.get_brief()
+            if brief is not None:
+                doc = list(documenter.process_doc(brief))
+                while doc and not doc[0].strip():
+                    doc.pop(0)
+                if doc:
+                    summary = doc[0].strip()
+                    items.append((display_name, sig, summary, real_name))
+                    continue
 
+            doc = list(documenter.process_doc([self.bridge.result.data]))
             while doc and not doc[0].strip():
                 doc.pop(0)
 
@@ -202,7 +211,6 @@ class DoxygenAutosummary(Autosummary):
 
 
 class DoxygenAutoEnum(DoxygenAutosummary):
-
     def get_items(self, names):
         env = self.state.document.settings.env
         self.name = names[0]


### PR DESCRIPTION
Hey,

Thanks for your awesome work!

I made a small modification to your code to allow the use of the [briefdescription](https://www.doxygen.nl/manual/commands.html#cmdbrief) in the autosummary tables.
If your class/method has a briefdescription it will be used in the autosummary, otherwise it defaults to your old behaviour.

Since you implemented `get_doc` separately in your `DoxygenClassDocumenter` and `DoxygenMethodDocumenter` classes, I did the same for `get_brief`, but maybe it would be nice to reformat that and put both methods straight in your `DoxygenDocumenter` class ? That way there is less code duplication (and you can still overwrite the function later down the line).
Let me know if you agree with this and I will push a new commit with these changes!

Kind Regards,