### PR TITLE
Fix errors on recent Sphinx

### DIFF
--- a/sphinxcontrib/autodoc_doxygen/autodoc.py
+++ b/sphinxcontrib/autodoc_doxygen/autodoc.py
@@ -245,7 +245,7 @@ class DoxygenMethodDocumenter(DoxygenDocumenter):
         types = [e.text for e in self.object.findall('templateparamlist/param/type')]
         if len(types) == 0:
             return ''
-        return 'template <%s>\n' % ','.join(types)
+        return 'template <%s> ' % ','.join(types)
 
     def format_signature(self):
         args = self.object.find('argsstring').text

--- a/sphinxcontrib/autodoc_doxygen/autosummary/__init__.py
+++ b/sphinxcontrib/autodoc_doxygen/autosummary/__init__.py
@@ -26,7 +26,7 @@ def import_by_name(name, env=None, prefixes=None, i=0):
     if env is not None:
         parents = env.ref_context.get('cpp:parent_key')
         if parents is not None:
-            parent_symbols = [p[0].get_display_string() for p in parents]
+            parent_symbols = [p[0].get_display_string() for p in parents.data]
             prefixes.append('::'.join(parent_symbols))
 
     tried = []
@@ -111,7 +111,7 @@ class DoxygenAutosummary(Autosummary):
                 continue
 
             self.bridge.result = StringList()  # initialize for each documenter
-            documenter = get_documenter(obj, parent)(self, real_name, id=obj.get('id'))
+            documenter = get_documenter(obj, parent)(self.bridge, real_name, id=obj.get('id'))
             if not documenter.parse_name():
                 self.warn('failed to parse name %s' % real_name)
                 items.append((display_name, '', '', real_name))
@@ -197,7 +197,7 @@ class DoxygenAutosummary(Autosummary):
             col2 = summary
             append_row(col1, col2)
 
-        self.result.append('   .. rubric: sdsf', 0)
+        self.bridge.result.append('   .. rubric: sdsf', 0)
         return [table_spec, table]
 
 


### PR DESCRIPTION
I'm trying to get this working with Sphinx 4.0.2.  I fixed several errors.  It now gets much of the way through reading the files before failing.  The log is given below.  I'm not sure how to debug it, since no classes from this extension appear in the stack trace.

```
# Sphinx version: 4.0.2
# Python version: 3.9.1 (CPython)
# Docutils version: 0.17.1 release
# Jinja2 version: 2.11.2
# Last messages:
#   reading sources... [ 68%] generated/OpenMM.NoseHooverIntegrator
#   reading sources... [ 70%] generated/OpenMM.OpenMMException
#   reading sources... [ 71%] generated/OpenMM.OutOfPlaneSite
#   reading sources... [ 72%] generated/OpenMM.PeriodicTorsionForce
#   reading sources... [ 74%] generated/OpenMM.Platform
#   reading sources... [ 75%] generated/OpenMM.RBTorsionForce
#   reading sources... [ 77%] generated/OpenMM.RMSDForce
#   reading sources... [ 78%] generated/OpenMM.RPMDIntegrator
#   reading sources... [ 79%] generated/OpenMM.RPMDMonteCarloBarostat
#   reading sources... [ 81%] generated/OpenMM.SerializationNode
# Loaded extensions:
#   sphinx.ext.mathjax (4.0.2) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/ext/mathjax.py
#   sphinxcontrib.applehelp (1.0.2) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinxcontrib/applehelp/__init__.py
#   sphinxcontrib.devhelp (1.0.2) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinxcontrib/devhelp/__init__.py
#   sphinxcontrib.htmlhelp (2.0.0) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinxcontrib/htmlhelp/__init__.py
#   sphinxcontrib.serializinghtml (1.1.5) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinxcontrib/serializinghtml/__init__.py
#   sphinxcontrib.qthelp (1.0.3) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinxcontrib/qthelp/__init__.py
#   alabaster (0.7.12) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/alabaster/__init__.py
#   sphinx.ext.autodoc.preserve_defaults (1.0) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/ext/autodoc/preserve_defaults.py
#   sphinx.ext.autodoc.type_comment (4.0.2) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/ext/autodoc/type_comment.py
#   sphinx.ext.autodoc (4.0.2) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/ext/autodoc/__init__.py
#   sphinx.ext.autosummary (4.0.2) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/ext/autosummary/__init__.py
#   sphinxcontrib.lunrsearch (unknown version) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinxcontrib_lunrsearch-0.4.dev0+gfd24e6a.d20210604-py3.9.egg/sphinxcontrib/lunrsearch/__init__.py
#   sphinxcontrib.autodoc_doxygen (4.0.2) from /Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinxcontrib/autodoc_doxygen/__init__.py
Traceback (most recent call last):
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/cmd/build.py", line 280, in build_main
    app.build(args.force_all, filenames)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/application.py", line 350, in build
    self.builder.build_update()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 292, in build_update
    self.build(to_build,
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 306, in build
    updated_docnames = set(self.read())
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 413, in read
    self._read_serial(docnames)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 434, in _read_serial
    self.read_doc(docname)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 474, in read_doc
    doctree = read_doc(self.app, self.env, self.env.doc2path(docname))
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/io.py", line 188, in read_doc
    pub.publish()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/core.py", line 217, in publish
    self.document = self.reader.read(self.source, self.parser,
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/io.py", line 108, in read
    self.parse()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/readers/__init__.py", line 78, in parse
    self.parser.parse(self.input, document)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/parsers.py", line 100, in parse
    self.statemachine.run(inputlines, document, inliner=self.inliner)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 170, in run
    results = StateMachineWS.run(self, input_lines, input_offset,
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 239, in run
    context, next_state, result = self.check_line(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 451, in check_line
    return method(match, context, next_state)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2769, in underline
    self.section(title, source, style, lineno - 1, messages)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 327, in section
    self.new_subsection(title, lineno, messages)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 393, in new_subsection
    newabsoffset = self.nested_parse(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 281, in nested_parse
    state_machine.run(block, input_offset, memo=self.memo,
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 239, in run
    context, next_state, result = self.check_line(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 451, in check_line
    return method(match, context, next_state)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2342, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2354, in explicit_construct
    return method(self, expmatch)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2096, in directive
    return self.run_directive(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2146, in run_directive
    result = directive_instance.run()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/ext/autodoc/directive.py", line 173, in run
    result = parse_generated_content(self.state, params.result, documenter)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/ext/autodoc/directive.py", line 120, in parse_generated_content
    state.nested_parse(content, 0, node)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 281, in nested_parse
    state_machine.run(block, input_offset, memo=self.memo,
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 239, in run
    context, next_state, result = self.check_line(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 451, in check_line
    return method(match, context, next_state)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2342, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2354, in explicit_construct
    return method(self, expmatch)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2096, in directive
    return self.run_directive(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2146, in run_directive
    result = directive_instance.run()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/domains/__init__.py", line 286, in run
    return super().run()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/domains/cpp.py", line 6976, in run
    return super().run()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/directives/__init__.py", line 208, in run
    self.state.nested_parse(self.content, self.content_offset, contentnode)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 281, in nested_parse
    state_machine.run(block, input_offset, memo=self.memo,
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 239, in run
    context, next_state, result = self.check_line(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 451, in check_line
    return method(match, context, next_state)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2344, in explicit_markup
    self.explicit_list(blank_finish)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2369, in explicit_list
    newline_offset, blank_finish = self.nested_list_parse(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 318, in nested_list_parse
    state_machine.run(block, input_offset, memo=self.memo,
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 196, in run
    results = StateMachineWS.run(self, input_lines, input_offset)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 239, in run
    context, next_state, result = self.check_line(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/statemachine.py", line 451, in check_line
    return method(match, context, next_state)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2647, in explicit_markup
    nodelist, blank_finish = self.explicit_construct(match)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2354, in explicit_construct
    return method(self, expmatch)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2096, in directive
    return self.run_directive(
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/docutils/parsers/rst/states.py", line 2146, in run_directive
    result = directive_instance.run()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/domains/__init__.py", line 286, in run
    return super().run()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/domains/cpp.py", line 6976, in run
    return super().run()
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/directives/__init__.py", line 189, in run
    name = self.handle_signature(sig, signode)
  File "/Users/peastman/miniconda3/envs/openmm/lib/python3.9/site-packages/sphinx/domains/cpp.py", line 7002, in handle_signature
    assert symbol.siblingAbove.siblingBelow is None
AssertionError
```